### PR TITLE
BP-4174 Removed checkout layout overwrite

### DIFF
--- a/view/frontend/layout/hyva_checkout_index_index.xml
+++ b/view/frontend/layout/hyva_checkout_index_index.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      layout="checkout"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd"
 >
     <body>


### PR DESCRIPTION
The module overwrites the standard layout of the Hyva checkout. By default this is `1column` in Hyva. However, the Buckaroo module overwrites this unnecessarily with the `checkout` layout.