### PR TITLE
BP-5208-Update-Test-Release-1.4.1-Hyvä-Checkout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Buckaroo Magento 2 hyva checkout extension",
     "require": {
         "php": ">=8.1",
-        "buckaroo/magento2": ">=1.50.1"
+        "buckaroo/magento2": ">=1.55.0"
     },
     "type": "magento2-module",
     "license": "CC-BY-NC-ND-3.0",
@@ -21,7 +21,7 @@
         "docs": "https://support.buckaroo.nl"
     },
     "homepage": "https://www.buckaroo.nl",
-    "version" : "v1.4.0",
+    "version" : "v1.4.1",
     "minimum-stability": "stable",
     "autoload": {
         "files": [


### PR DESCRIPTION
update: bump Buckaroo Magento 2 dependency to version 1.55.0 and update module version to 1.4.1