### PR TITLE
BP-5369-Deprecated-PHP-warning-causes-500-error-for-multiple-payment-methods-Rakit-Validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": ">=8.1",
         "buckaroo/magento2": ">=2.2.0",
-        "rakit/validation": "^1.4"
+        "magewirephp/validation": "^1.0"
     },
     "type": "magento2-module",
     "license": "CC-BY-NC-ND-3.0",


### PR DESCRIPTION
magewirephp/validation is a fork of rakit/validation which also supports php 8.4

reference: https://github.com/magewirephp/validation