### PR TITLE
BTI-889-Magento-2-Hyvä-Checkout-Buckaroo_HyvaCheckout-breaks-PayPal-Express-button-on-Luma-when-module-is-enabled

### DIFF
--- a/Observer/ApplyHyvaLayoutOverrides.php
+++ b/Observer/ApplyHyvaLayoutOverrides.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buckaroo\HyvaCheckout\Observer;
+
+use Buckaroo\HyvaCheckout\Service\IsHyvaTheme;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\View\LayoutInterface;
+
+/**
+ * Applies Hyvä-specific block swaps only when the active theme is actually Hyvä.
+ */
+class ApplyHyvaLayoutOverrides implements ObserverInterface
+{
+    private const CART_LUMA_BLOCK = 'buckaroo.paypal.express.cart.button';
+    private const CART_HYVA_BLOCK = 'buckaroo.paypal.express.cart.button.hyva';
+    private const CART_HYVA_CLASS = \Buckaroo\HyvaCheckout\Block\Checkout\Cart\PaypalExpress::class;
+    private const CART_HYVA_TEMPLATE = 'Buckaroo_HyvaCheckout::checkout/cart/paypal-express.phtml';
+    private const CART_CONTAINER = 'content';
+
+    private const PDP_BLOCK = 'buckaroo_magento2.product.info.paypal.express';
+    private const PDP_HYVA_TEMPLATE = 'Buckaroo_HyvaCheckout::catalog/product/view/paypal-express.phtml';
+
+    /**
+     * @var IsHyvaTheme
+     */
+    private $isHyvaTheme;
+
+    public function __construct(IsHyvaTheme $isHyvaTheme)
+    {
+        $this->isHyvaTheme = $isHyvaTheme;
+    }
+
+    public function execute(Observer $observer): void
+    {
+        if (!$this->isHyvaTheme->execute()) {
+            return;
+        }
+
+        /** @var LayoutInterface|null $layout */
+        $layout = $observer->getEvent()->getLayout();
+        if (!$layout instanceof LayoutInterface) {
+            return;
+        }
+
+        $handles = $layout->getUpdate()->getHandles();
+
+        if (in_array('checkout_cart_index', $handles, true)) {
+            $this->applyCartOverride($layout);
+        }
+
+        if (in_array('catalog_product_view', $handles, true)) {
+            $this->applyPdpOverride($layout);
+        }
+    }
+
+    /**
+     * Replace the Luma cart PayPal block with the Hyvä variant inside the main content container.
+     */
+    private function applyCartOverride(LayoutInterface $layout): void
+    {
+        $lumaBlock = $layout->getBlock(self::CART_LUMA_BLOCK);
+        if ($lumaBlock !== false) {
+            $layout->unsetElement(self::CART_LUMA_BLOCK);
+        }
+
+        if ($layout->getBlock(self::CART_HYVA_BLOCK) !== false) {
+            return;
+        }
+
+        $hyvaBlock = $layout->createBlock(
+            self::CART_HYVA_CLASS,
+            self::CART_HYVA_BLOCK,
+            ['data' => ['template' => self::CART_HYVA_TEMPLATE]]
+        );
+
+        if (!$layout->hasElement(self::CART_CONTAINER)) {
+            return;
+        }
+
+        $layout->setChild(self::CART_CONTAINER, $hyvaBlock->getNameInLayout(), self::CART_HYVA_BLOCK);
+    }
+
+    /**
+     * Repoint the shared Luma PDP PayPal block at the Hyvä template.
+     */
+    private function applyPdpOverride(LayoutInterface $layout): void
+    {
+        $block = $layout->getBlock(self::PDP_BLOCK);
+        if ($block === false) {
+            return;
+        }
+
+        $block->setTemplate(self::PDP_HYVA_TEMPLATE);
+    }
+}

--- a/Service/IsHyvaTheme.php
+++ b/Service/IsHyvaTheme.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buckaroo\HyvaCheckout\Service;
+
+use Magento\Framework\View\DesignInterface;
+
+/**
+ * Detects whether the currently active frontend theme belongs to the Hyvä family.
+ *
+ * The module is allowed to be enabled on stores that are not running Hyvä themes
+ * (composer/sequence dependencies on Hyvä packages are optional here), so any
+ * layout override, block swap, or template replacement the module performs MUST
+ * be guarded with this service. Walks the theme inheritance chain looking for a
+ * `hyva` substring in the theme code, mirroring the runtime check that
+ * `Hyva\Theme\Service\CurrentTheme::isHyva()` performs when the package is present.
+ */
+class IsHyvaTheme
+{
+    /**
+     * @var DesignInterface
+     */
+    private $design;
+
+    /**
+     * @var bool|null
+     */
+    private $cached;
+
+    public function __construct(DesignInterface $design)
+    {
+        $this->design = $design;
+    }
+
+    /**
+     * Return true when the active theme (or any ancestor) is a Hyvä theme.
+     */
+    public function execute(): bool
+    {
+        if ($this->cached !== null) {
+            return $this->cached;
+        }
+
+        try {
+            $theme = $this->design->getDesignTheme();
+        } catch (\Throwable $e) {
+            return $this->cached = false;
+        }
+
+        while ($theme !== null) {
+            $code = (string)$theme->getCode();
+            if ($code !== '' && stripos($code, 'hyva') !== false) {
+                return $this->cached = true;
+            }
+            $theme = $theme->getParentTheme();
+        }
+
+        return $this->cached = false;
+    }
+}

--- a/Test/Unit/Observer/ApplyHyvaLayoutOverridesTest.php
+++ b/Test/Unit/Observer/ApplyHyvaLayoutOverridesTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buckaroo\HyvaCheckout\Test\Unit\Observer;
+
+use Buckaroo\HyvaCheckout\Observer\ApplyHyvaLayoutOverrides;
+use Buckaroo\HyvaCheckout\Service\IsHyvaTheme;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\View\Element\AbstractBlock;
+use Magento\Framework\View\Layout\ProcessorInterface;
+use Magento\Framework\View\LayoutInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the theme guard and the cart/PDP block swaps performed when the active
+ * theme is Hyvä. The observer used to live as raw layout XML under generic
+ * handles, which broke PayPal Express on Luma; these tests lock in the gated
+ * behaviour so the regression cannot reappear.
+ */
+class ApplyHyvaLayoutOverridesTest extends TestCase
+{
+    private const CART_LUMA_BLOCK = 'buckaroo.paypal.express.cart.button';
+    private const CART_HYVA_BLOCK = 'buckaroo.paypal.express.cart.button.hyva';
+    private const CART_HYVA_CLASS = \Buckaroo\HyvaCheckout\Block\Checkout\Cart\PaypalExpress::class;
+    private const CART_HYVA_TEMPLATE = 'Buckaroo_HyvaCheckout::checkout/cart/paypal-express.phtml';
+    private const CART_CONTAINER = 'content';
+    private const PDP_BLOCK = 'buckaroo_magento2.product.info.paypal.express';
+    private const PDP_HYVA_TEMPLATE = 'Buckaroo_HyvaCheckout::catalog/product/view/paypal-express.phtml';
+
+    public function testNoopWhenThemeIsNotHyva(): void
+    {
+        $isHyvaTheme = $this->createMock(IsHyvaTheme::class);
+        $isHyvaTheme->method('execute')->willReturn(false);
+
+        $layout = $this->createMock(LayoutInterface::class);
+        $layout->expects(self::never())->method('unsetElement');
+        $layout->expects(self::never())->method('createBlock');
+        $layout->expects(self::never())->method('setChild');
+
+        (new ApplyHyvaLayoutOverrides($isHyvaTheme))->execute($this->makeObserver($layout));
+    }
+
+    public function testSwapsCartBlockOnHyvaCartPage(): void
+    {
+        $layout = $this->createLayoutMock(['checkout_cart_index']);
+
+        $lumaBlock = $this->createMock(AbstractBlock::class);
+        $hyvaBlock = $this->createMock(AbstractBlock::class);
+        $hyvaBlock->method('getNameInLayout')->willReturn(self::CART_HYVA_BLOCK);
+
+        $layout->method('getBlock')->willReturnMap([
+            [self::CART_LUMA_BLOCK, $lumaBlock],
+            [self::CART_HYVA_BLOCK, false],
+        ]);
+        $layout->expects(self::once())->method('unsetElement')->with(self::CART_LUMA_BLOCK);
+        $layout->expects(self::once())
+            ->method('createBlock')
+            ->with(
+                self::CART_HYVA_CLASS,
+                self::CART_HYVA_BLOCK,
+                ['data' => ['template' => self::CART_HYVA_TEMPLATE]]
+            )
+            ->willReturn($hyvaBlock);
+        $layout->method('hasElement')->with(self::CART_CONTAINER)->willReturn(true);
+        $layout->expects(self::once())
+            ->method('setChild')
+            ->with(self::CART_CONTAINER, self::CART_HYVA_BLOCK, self::CART_HYVA_BLOCK);
+
+        (new ApplyHyvaLayoutOverrides($this->hyvaTheme()))->execute($this->makeObserver($layout));
+    }
+
+    public function testSkipsCartSwapWhenHyvaBlockAlreadyExists(): void
+    {
+        $layout = $this->createLayoutMock(['checkout_cart_index']);
+
+        $layout->method('getBlock')->willReturnMap([
+            [self::CART_LUMA_BLOCK, $this->createMock(AbstractBlock::class)],
+            [self::CART_HYVA_BLOCK, $this->createMock(AbstractBlock::class)],
+        ]);
+        $layout->expects(self::once())->method('unsetElement')->with(self::CART_LUMA_BLOCK);
+        $layout->expects(self::never())->method('createBlock');
+        $layout->expects(self::never())->method('setChild');
+
+        (new ApplyHyvaLayoutOverrides($this->hyvaTheme()))->execute($this->makeObserver($layout));
+    }
+
+    public function testSkipsContentAttachmentWhenContainerMissing(): void
+    {
+        $layout = $this->createLayoutMock(['checkout_cart_index']);
+
+        $hyvaBlock = $this->createMock(AbstractBlock::class);
+        $hyvaBlock->method('getNameInLayout')->willReturn(self::CART_HYVA_BLOCK);
+
+        $layout->method('getBlock')->willReturnMap([
+            [self::CART_LUMA_BLOCK, false],
+            [self::CART_HYVA_BLOCK, false],
+        ]);
+        $layout->method('createBlock')->willReturn($hyvaBlock);
+        $layout->method('hasElement')->with(self::CART_CONTAINER)->willReturn(false);
+        $layout->expects(self::never())->method('setChild');
+
+        (new ApplyHyvaLayoutOverrides($this->hyvaTheme()))->execute($this->makeObserver($layout));
+    }
+
+    public function testRetargetsPdpBlockTemplateOnHyvaProductPage(): void
+    {
+        $layout = $this->createLayoutMock(['catalog_product_view']);
+
+        $pdpBlock = $this->createMock(AbstractBlock::class);
+        $pdpBlock->expects(self::once())->method('setTemplate')->with(self::PDP_HYVA_TEMPLATE);
+
+        $layout->method('getBlock')->with(self::PDP_BLOCK)->willReturn($pdpBlock);
+
+        (new ApplyHyvaLayoutOverrides($this->hyvaTheme()))->execute($this->makeObserver($layout));
+    }
+
+    public function testPdpOverrideSilentWhenBlockMissing(): void
+    {
+        $layout = $this->createLayoutMock(['catalog_product_view']);
+        $layout->method('getBlock')->with(self::PDP_BLOCK)->willReturn(false);
+
+        // Must not blow up and must not attempt setTemplate on false.
+        $this->expectNotToPerformAssertions();
+
+        (new ApplyHyvaLayoutOverrides($this->hyvaTheme()))->execute($this->makeObserver($layout));
+    }
+
+    public function testIgnoresUnrelatedLayoutHandles(): void
+    {
+        $layout = $this->createLayoutMock(['cms_page_view']);
+        $layout->expects(self::never())->method('getBlock');
+        $layout->expects(self::never())->method('unsetElement');
+        $layout->expects(self::never())->method('createBlock');
+
+        (new ApplyHyvaLayoutOverrides($this->hyvaTheme()))->execute($this->makeObserver($layout));
+    }
+
+    public function testSilentWhenObserverEventHasNoLayout(): void
+    {
+        $event = new DataObject();
+        $observer = new Observer();
+        $observer->setEvent($event);
+
+        $this->expectNotToPerformAssertions();
+
+        (new ApplyHyvaLayoutOverrides($this->hyvaTheme()))->execute($observer);
+    }
+
+    /**
+     * @return LayoutInterface&MockObject
+     */
+    private function createLayoutMock(array $handles)
+    {
+        $processor = $this->createMock(ProcessorInterface::class);
+        $processor->method('getHandles')->willReturn($handles);
+
+        $layout = $this->createMock(LayoutInterface::class);
+        $layout->method('getUpdate')->willReturn($processor);
+
+        return $layout;
+    }
+
+    /**
+     * @param LayoutInterface&MockObject $layout
+     */
+    private function makeObserver($layout): Observer
+    {
+        $event = new DataObject(['layout' => $layout]);
+        $observer = new Observer();
+        $observer->setEvent($event);
+        return $observer;
+    }
+
+    /**
+     * @return IsHyvaTheme&MockObject
+     */
+    private function hyvaTheme()
+    {
+        $service = $this->createMock(IsHyvaTheme::class);
+        $service->method('execute')->willReturn(true);
+        return $service;
+    }
+}

--- a/Test/Unit/Service/IsHyvaThemeTest.php
+++ b/Test/Unit/Service/IsHyvaThemeTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Buckaroo\HyvaCheckout\Test\Unit\Service;
+
+use Buckaroo\HyvaCheckout\Service\IsHyvaTheme;
+use Magento\Framework\View\Design\ThemeInterface;
+use Magento\Framework\View\DesignInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards module behaviour so it only touches layout when the active theme is Hyvä.
+ * Exercises the theme-chain walk and the early-return paths that kept the module
+ * from breaking Luma stores when Buckaroo_HyvaCheckout was mistakenly enabled.
+ */
+class IsHyvaThemeTest extends TestCase
+{
+    public function testReturnsTrueWhenActiveThemeCodeContainsHyva(): void
+    {
+        $theme = $this->makeTheme('Hyva/default');
+        $design = $this->createMock(DesignInterface::class);
+        $design->method('getDesignTheme')->willReturn($theme);
+
+        self::assertTrue((new IsHyvaTheme($design))->execute());
+    }
+
+    public function testReturnsTrueWhenParentThemeIsHyva(): void
+    {
+        $hyvaParent = $this->makeTheme('Hyva/default');
+        $child = $this->makeTheme('Acme/storefront', $hyvaParent);
+        $design = $this->createMock(DesignInterface::class);
+        $design->method('getDesignTheme')->willReturn($child);
+
+        self::assertTrue((new IsHyvaTheme($design))->execute());
+    }
+
+    public function testReturnsFalseForLumaDescendantChain(): void
+    {
+        $luma = $this->makeTheme('Magento/luma');
+        $blank = $this->makeTheme('Magento/blank', $luma);
+        $design = $this->createMock(DesignInterface::class);
+        $design->method('getDesignTheme')->willReturn($blank);
+
+        self::assertFalse((new IsHyvaTheme($design))->execute());
+    }
+
+    public function testReturnsFalseAndCachesWhenDesignThrows(): void
+    {
+        $design = $this->createMock(DesignInterface::class);
+        $design->expects(self::once())
+            ->method('getDesignTheme')
+            ->willThrowException(new \RuntimeException('design not ready'));
+
+        $service = new IsHyvaTheme($design);
+
+        self::assertFalse($service->execute());
+        self::assertFalse($service->execute()); // cached, no second call
+    }
+
+    public function testResultIsCachedAcrossCalls(): void
+    {
+        $theme = $this->makeTheme('Hyva/default');
+        $design = $this->createMock(DesignInterface::class);
+        $design->expects(self::once())->method('getDesignTheme')->willReturn($theme);
+
+        $service = new IsHyvaTheme($design);
+
+        self::assertTrue($service->execute());
+        self::assertTrue($service->execute());
+    }
+
+    private function makeTheme(string $code, ?ThemeInterface $parent = null): ThemeInterface
+    {
+        $theme = $this->createMock(ThemeInterface::class);
+        $theme->method('getCode')->willReturn($code);
+        $theme->method('getParentTheme')->willReturn($parent);
+        return $theme;
+    }
+}

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="layout_generate_blocks_after">
+        <observer name="buckaroo_hyvacheckout_apply_hyva_layout_overrides"
+                  instance="Buckaroo\HyvaCheckout\Observer\ApplyHyvaLayoutOverrides"/>
+    </event>
+</config>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -2,14 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="Buckaroo_Magento2::css/express-payments.css"/>
         <css src="Buckaroo_HyvaCheckout::css/buckaroo-components.css"/>
-        <script src="jquery/jquery.min.js"/>
-        <script src="Buckaroo_Magento2::js/lib/buckaroo-sdk.js"/>
         <script src="Buckaroo_HyvaCheckout::js/paypal-express-product.js"/>
     </head>
-    <body>
-        <referenceBlock name="buckaroo_magento2.product.info.paypal.express"
-                         template="Buckaroo_HyvaCheckout::catalog/product/view/paypal-express.phtml"/>
-    </body>
 </page>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -2,19 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="Buckaroo_Magento2::css/express-payments.css"/>
         <css src="Buckaroo_HyvaCheckout::css/buckaroo-components.css"/>
-        <script src="jquery/jquery.min.js"/>
-        <script src="Buckaroo_Magento2::js/lib/buckaroo-sdk.js"/>
         <script src="Buckaroo_HyvaCheckout::js/paypal-express-cart.js"/>
     </head>
-    <body>
-        <referenceBlock name="buckaroo.paypal.express.cart.button" remove="true"/>
-        <referenceContainer name="content">
-            <block class="Buckaroo\HyvaCheckout\Block\Checkout\Cart\PaypalExpress"
-                   name="buckaroo.paypal.express.cart.button.hyva"
-                   template="Buckaroo_HyvaCheckout::checkout/cart/paypal-express.phtml"
-                   after="checkout.cart"/>
-        </referenceContainer>
-    </body>
 </page>


### PR DESCRIPTION
implement Hyvä layout overrides for PayPal Express integration