### PR TITLE
Reflect tickets released in main magento module

### DIFF
--- a/Magewire/Payment/Method/Billink.php
+++ b/Magewire/Payment/Method/Billink.php
@@ -49,6 +49,8 @@ class Billink extends Component\Form implements EvaluationInterface
 
     public const RULES_DATE_OF_BIRTH = ['required', 'date', 'before:-18 years'];
 
+    private const GENDER_UNKNOWN = 'unknown';
+
     protected SessionCheckout $sessionCheckout;
 
     protected CartRepositoryInterface $quoteRepository;
@@ -97,10 +99,11 @@ class Billink extends Component\Form implements EvaluationInterface
 
         $this->tos = $tos === true;
         $this->coc = $payment->getAdditionalInformation('customer_chamberOfCommerce');
-        $this->phone = $payment->getAdditionalInformation('customer_telephone');
+        $this->phone = $this->getBillingTelephone()
+            ?: $payment->getAdditionalInformation('customer_telephone');
         $this->vatNumber = $payment->getAdditionalInformation('customer_VATNumber');
         $this->dateOfBirth = $payment->getAdditionalInformation('customer_DoB');
-        $this->gender = $payment->getAdditionalInformation('customer_gender');
+        $this->gender = self::GENDER_UNKNOWN;
         $this->fullName = $this->getFullName();
     }
 
@@ -231,6 +234,9 @@ class Billink extends Component\Form implements EvaluationInterface
 
     public function evaluateCompletion(EvaluationResultFactory $resultFactory): EvaluationResultInterface
     {
+        $this->useBillingPhoneWhenAvailable();
+        $this->useUnknownGenderForB2c();
+
         $validation = $this->validator->validate(
             $this->getFormValues(),
             $this->getFormRules()
@@ -293,23 +299,68 @@ class Billink extends Component\Form implements EvaluationInterface
     }
 
     /**
+     * Get billing telephone from quote
+     *
+     * @return string|null
+     */
+    private function getBillingTelephone(): ?string
+    {
+        $quote = $this->getQuote();
+        if ($quote === null) {
+            return null;
+        }
+
+        $telephone = trim((string)$quote->getBillingAddress()->getTelephone());
+
+        return $telephone !== '' ? $telephone : null;
+    }
+
+    /**
+     * Use billing telephone for Billink when no fallback input is needed
+     *
+     * @return void
+     */
+    private function useBillingPhoneWhenAvailable(): void
+    {
+        $billingTelephone = $this->getBillingTelephone();
+        if ($billingTelephone === null) {
+            return;
+        }
+
+        $this->phone = $billingTelephone;
+        $this->updatePaymentField('customer_telephone', $billingTelephone);
+    }
+
+    /**
+     * Billink accepts unknown salutation, so B2C customers should not need to choose one.
+     *
+     * @return void
+     */
+    private function useUnknownGenderForB2c(): void
+    {
+        if ($this->showB2b()) {
+            return;
+        }
+
+        $this->gender = self::GENDER_UNKNOWN;
+        $this->updatePaymentField('customer_gender', self::GENDER_UNKNOWN);
+    }
+
+    /**
      * Get form values
      *
      * @return array
      */
     private function getFormValues(): array
     {
-        $values = [
-            'tos' => $this->tos
-        ];
+        $values = [];
 
         if ($this->showPhone()) {
             $values = array_merge($values, ['phone' => $this->phone]);
         }
         if(!$this->showB2b()) {
             $values = array_merge($values, [
-                'dateOfBirth' => $this->dateOfBirth,
-                'gender' => $this->gender
+                'dateOfBirth' => $this->dateOfBirth
             ]);
         }
         if($this->showB2b()) {
@@ -330,14 +381,11 @@ class Billink extends Component\Form implements EvaluationInterface
      */
     private function getFormRules(): array
     {
-        $rules = [
-            'tos' => self::RULES_TOS
-        ];
+        $rules = [];
 
         if(!$this->showB2b()) {
             $rules = array_merge($rules, [
-                'dateOfBirth' => self::RULES_DATE_OF_BIRTH,
-                'gender' => $this->getGenderRules()
+                'dateOfBirth' => self::RULES_DATE_OF_BIRTH
             ]);
 
         }
@@ -374,23 +422,13 @@ class Billink extends Component\Form implements EvaluationInterface
 
 
     /**
-     * Show phone number field if phone is invalid
+     * Show phone number field only when billing phone is missing
      *
      * @return bool
      */
     public function showPhone(): bool
     {
-        $quote = $this->getQuote();
-
-        if ($quote === null) {
-            return true;
-        }
-        $validation = $this->validator->validate(
-            ["phone" => $quote->getBillingAddress()->getTelephone()],
-            ["phone" => $this->getPhoneRules()]
-        );
-
-        return $validation->fails();
+        return $this->getBillingTelephone() === null;
     }
 
     public function getGenderList(): array

--- a/Magewire/Payment/Method/PayPerEmail.php
+++ b/Magewire/Payment/Method/PayPerEmail.php
@@ -327,9 +327,9 @@ class PayPerEmail extends Component\Form implements EvaluationInterface
     public function getGenderList(): array
     {
         return [
-            ['code' => 1, 'name' => __('He/him')],
-            ['code' => 2, 'name' => __('She/her')],
-            ['code' => 0, 'name' => __('They/them')],
+            ['code' => 1, 'name' => __('Male')],
+            ['code' => 2, 'name' => __('Female')],
+            ['code' => 0, 'name' => __('Other')],
             ['code' => 9, 'name' => __('I prefer not to say')]
         ];
     }

--- a/Plugin/MethodList.php
+++ b/Plugin/MethodList.php
@@ -4,6 +4,7 @@ namespace Buckaroo\HyvaCheckout\Plugin;
 
 use Magento\Framework\View\Element\Template;
 use Hyva\Checkout\Model\MethodMetaDataInterface;
+use Buckaroo\Magento2\Model\Config\Source\TransferPaymentMethodLogo;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Factory;
 use Magento\Payment\Model\MethodInterface as PaymentMethodInterface;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\ConfigProviderInterface;
@@ -48,6 +49,11 @@ class MethodList implements \Magento\Framework\View\Element\Block\ArgumentInterf
     private function getSvgLogo(string $methodCode): string
     {
         $method = str_replace("buckaroo_magento2_", "", $methodCode);
+
+        if ($method === "transfer") {
+            return "Buckaroo_Magento2::images/{$this->getTransferLogoPath($methodCode)}";
+        }
+
         $mappings = [
             "afterpay2" => "svg/afterpay.svg",
             "afterpay20" => "svg/afterpay.svg",
@@ -56,6 +62,7 @@ class MethodList implements \Magento\Framework\View\Element\Block\ArgumentInterf
             "creditcard" => "svg/creditcards.svg",
             "creditcards" => "svg/creditcards.svg",
             "giftcards" => "svg/giftcards.svg",
+            "ideal" => "svg/ideal-wero.svg",
             "idealprocessing" => "svg/ideal.svg",
             "klarnakp" => "svg/klarna.svg",
             "mrcash" => "svg/bancontact.svg",
@@ -63,7 +70,6 @@ class MethodList implements \Magento\Framework\View\Element\Block\ArgumentInterf
             "sepadirectdebit" => "svg/sepa-directdebit.svg",
             "emandate" => "emandate.png",
             "pospayment" => "pos.png",
-            "transfer" => "svg/sepa-credittransfer.svg",
             "voucher" => "svg/vouchers.svg",
             "paybybank" => "paybybank.gif",
             "knaken" => "svg/gosettle.svg",
@@ -76,6 +82,20 @@ class MethodList implements \Magento\Framework\View\Element\Block\ArgumentInterf
         }
 
         return "Buckaroo_Magento2::images/{$name}";
+    }
+
+    private function getTransferLogoPath(string $methodCode): string
+    {
+        $config = $this->getConfig($methodCode);
+        $option = TransferPaymentMethodLogo::OPTION_GENERIC_BANK_LOGO;
+
+        if (method_exists($config, 'getPaymentMethodLogo')) {
+            $option = $config->getPaymentMethodLogo();
+        }
+
+        return $option === TransferPaymentMethodLogo::OPTION_SEPA_CREDIT_TRANSFER
+            ? "svg/sepa-directdebit.svg"
+            : "svg/sepa-credittransfer.svg";
     }
 
     private function getSubtitle(string $methodCode): ?string

--- a/view/frontend/templates/component/payment/method/billink.phtml
+++ b/view/frontend/templates/component/payment/method/billink.phtml
@@ -7,34 +7,8 @@ declare(strict_types=1);
 use Magento\Framework\Escaper;
 ?>
 <div class="col-span-6">
-    <div class="flex flex-col gap-y-2 field field-reserved">
-        <label for="buckaroo_billink_tos_fullname">
-            <?= $escaper->escapeHtml(__('Billing Name:')); ?>
-        </label>
-        <input type="text" wire:model.lazy="fullName" disabled id="buckaroo_billink_tos_fullname" class="bg-gray-200">
-    </div>
-
     <?php if (!$magewire->showB2b()) {
         ?>
-        <div class="flex flex-col gap-y-2 field field-reserved">
-            <label for="buckaroo_klarna_gender"><?= $escaper->escapeHtml(__('Salutation:')); ?></label>
-            <select name="issuer" id="buckaroo_klarna_gender" wire:model="gender" class="form-select">
-                <option value=""><?= $escaper->escapeHtml(__('-- Please Select Your Gender--')); ?></option>
-                <?php
-                foreach ($magewire->getGenderList() as $gender) {
-                    ?>
-                    <option value="<?= $escaper->escapeHtmlAttr($gender["code"]) ?>">
-                        <?= $escaper->escapeHtml($gender["name"]) ?>
-                    </option>
-                    <?php
-                }
-                ?>
-            </select>
-            <?php if ($magewire->hasError('gender')) : ?>
-                <div class="text-red-600"><?= $escaper->escapeHtmlAttr($magewire->getError('gender')) ?></div>
-            <?php endif; ?>
-        </div>
-
         <div class="flex flex-col gap-y-2 field field-reserved">
             <label for="buckaroo_billink_dob">
                 <?= $escaper->escapeHtml(__('Date of Birth:')); ?>
@@ -95,26 +69,4 @@ use Magento\Framework\Escaper;
         <?php
     } ?>
 
-    <div class="flex flex-col gap-y-2 ">
-        <label for="buckaroo_billink_tos"><?= $escaper->escapeHtml(__('Terms and Conditions:')); ?></label>
-        <div class="flex flex-row gap-x-2">
-            <input class="mt-1" type="checkbox" wire:model.lazy="tos" id="buckaroo_billink_tos">
-            <a
-                target="_blank"
-                class="grow"
-                href="https://www.billink.nl/app/uploads/2021/05/Gebruikersvoorwaarden-Billink_V11052021.pdf"
-            >
-                <?= $escaper->escapeHtml(__('Accept terms of use')) ?>
-            </a>
-        </div>
-        <?php if ($magewire->hasError('tos')) : ?>
-            <div class="text-red-600"><?= $escaper->escapeHtmlAttr($magewire->getError('tos')) ?></div>
-        <?php endif; ?>
-    </div>
-
-    <?php if ($magewire->showFinancialWarning()) : ?>
-        <div class="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded text-sm text-gray-700">
-            <?= /* @noEscape */ $magewire->getFinancialWarningMessage() ?>
-        </div>
-    <?php endif; ?>
 </div>

--- a/view/frontend/templates/component/payment/method/payperemail.phtml
+++ b/view/frontend/templates/component/payment/method/payperemail.phtml
@@ -9,7 +9,7 @@ use Magento\Framework\Escaper;
 ?>
 <div class="col-span-6">
     <div class="flex flex-col gap-y-2 field field-reserved">
-        <label for="buckaroo_klarna_gender"><?= $escaper->escapeHtml(__('Salutation:')); ?></label>
+        <label for="buckaroo_klarna_gender"><?= $escaper->escapeHtml(__('Gender:')); ?></label>
         <select name="issuer" id="buckaroo_klarna_gender" wire:model="gender" class="form-select">
             <option value=""><?= $escaper->escapeHtml(__('-- Please Select Your Gender--')); ?></option>
             <?php


### PR DESCRIPTION
This PR includes changes for these tickets:
BTI-941 | Incorrect use of gender field (pronouns shown instead of gender) in PayPerEmail module
BTI-942 | Simplify Billink checkout flow by removing phone number and billing name fields
BTI-943 | Remove optional salutation selection step for Billink
BTI-944 | Remove financial warning setting and text for Billink, now displayed on the Billink One page
BTI-945 | Update iDEAL to the co-branded payment method name iDEAL | Wero
BTI-949 | Add bank transfer logo selection, allowing a choice between international and European SEPA logos